### PR TITLE
Fix/use is mobile

### DIFF
--- a/src/components/Page/Page.styles.ts
+++ b/src/components/Page/Page.styles.ts
@@ -9,13 +9,13 @@ const StyledPage = styled.div`
   grid-template-rows: max-content max-content;
   height: 100%;
   justify-content: center;
-  margin: 5% 10% 0 10%;
+  margin: 8% 10% 0 10%;
   background-color: ${COLORS.header};
   max-width: 100vw;
   overflow: hidden;
 
-  @media (max-width: ${BREAKPOINTS.smRem}) {
-    margin: 0 0;
+  @media (max-width: ${BREAKPOINTS.mdRem}) {
+    margin: 10% 10% 0 10%;
   }
 `
 

--- a/src/components/Page/Page.styles.ts
+++ b/src/components/Page/Page.styles.ts
@@ -11,7 +11,8 @@ const StyledPage = styled.div`
   justify-content: center;
   margin: 5% 10% 0 10%;
   background-color: ${COLORS.header};
-  width: 100%:
+  max-width: 100vw;
+  overflow: hidden;
 
   @media (max-width: ${BREAKPOINTS.smRem}) {
     margin: 0 0;

--- a/src/components/Page/__snapshots__/Page.spec.tsx.snap
+++ b/src/components/Page/__snapshots__/Page.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Page /> should match Page snapshot 1`] = `
   data-sal-easing="ease"
 >
   <div
-    className="foo css-1p6xk4t"
+    className="foo css-h8saaj"
     id="foo"
     style={
       Object {

--- a/src/components/ProfileImage/ProfileImage.styles.ts
+++ b/src/components/ProfileImage/ProfileImage.styles.ts
@@ -22,6 +22,11 @@ const ProfileImageOuterBorder = styled('div')`
 const ProfileImage = styled(Img)`
   border-radius: 50%;
   border: 0.25rem solid white;
+
+  @media (max-width: 47.9375rem) {
+    height: 9.375rem !important;
+    width: 9.375rem !important;
+  }
 `
 
 export default {

--- a/src/components/ProfileImage/index.tsx
+++ b/src/components/ProfileImage/index.tsx
@@ -1,27 +1,17 @@
 import React, { FC } from 'react'
-import { useStaticQuery, graphql } from 'gatsby'
 import Styled from './ProfileImage.styles'
-import useIsMobile from '../../hooks/useIsMobile'
+import { graphql, useStaticQuery } from 'gatsby'
 
 /**
  *`Simple Component that shows users Profile Image
  *
- * @returns
  */
 const ProfileImage: FC<{}> = () => {
-  const isMobile = useIsMobile()
-  const { desktopImage, mobileImage } = useStaticQuery(graphql`
+  const { desktopImage } = useStaticQuery(graphql`
     query {
       desktopImage: file(relativePath: { eq: "nrs.jpeg" }) {
         sharp: childImageSharp {
           fixed(width: 200, height: 200, quality: 100) {
-            ...GatsbyImageSharpFixed
-          }
-        }
-      }
-      mobileImage: file(relativePath: { eq: "nrs.jpeg" }) {
-        sharp: childImageSharp {
-          fixed(width: 150, height: 150, quality: 100) {
             ...GatsbyImageSharpFixed
           }
         }
@@ -32,7 +22,7 @@ const ProfileImage: FC<{}> = () => {
   return (
     <Styled.ProfileImageOuterBorder>
       <Styled.ProfileImage
-        fixed={isMobile ? mobileImage.sharp.fixed : desktopImage.sharp.fixed}
+        fixed={desktopImage.sharp.fixed}
         alt="Profile Image"
       />
     </Styled.ProfileImageOuterBorder>

--- a/src/components/ToggleTabs/ToggleTabs.styles.ts
+++ b/src/components/ToggleTabs/ToggleTabs.styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { COLORS } from '../../styles/variables'
+import { BREAKPOINTS, COLORS } from '../../styles/variables'
 import { motion } from 'framer-motion'
 
 const ToggleSection = styled(motion.div)`
@@ -7,11 +7,19 @@ const ToggleSection = styled(motion.div)`
   grid-template-columns: max-content 1fr;
   grid-template-rows: repeat(2, max-content);
   grid-column-gap: 8%;
+
+  @media (max-width: ${BREAKPOINTS.mdRem}) {
+    display: none;
+  }
 `
 
 const MobileAccordionContainer = styled.div`
-  display: grid;
-  grid-template-columns: 1fr;
+  display: none;
+
+  @media (max-width: ${BREAKPOINTS.mdRem}) {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
 `
 
 const MobileAccordion = styled(motion.section)`

--- a/src/components/ToggleTabs/index.tsx
+++ b/src/components/ToggleTabs/index.tsx
@@ -1,9 +1,8 @@
 import React, { FC } from 'react'
-import { ToggleTabsProps } from '../../types'
-import Styled from './ToggleTabs.styles'
-import useIsMobile from '../../hooks/useIsMobile'
-import { SLIDE_DOWN_ANIMATION_OPTIONS } from '../../styles/variables'
 import setActiveClassName from '../../utils/setActiveClassName'
+import Styled from './ToggleTabs.styles'
+import { SLIDE_DOWN_ANIMATION_OPTIONS } from '../../styles/variables'
+import { ToggleTabsProps } from '../../types'
 
 const ToggleTabs: FC<ToggleTabsProps> = ({
   children,
@@ -11,8 +10,6 @@ const ToggleTabs: FC<ToggleTabsProps> = ({
   selectedItem,
   setSelectedItem,
 }) => {
-  const isMobile = useIsMobile()
-
   const renderDesktopTabs = () => (
     <Styled.ToggleSection>
       <Styled.ToggleTabsContainer>
@@ -58,7 +55,12 @@ const ToggleTabs: FC<ToggleTabsProps> = ({
     </Styled.MobileAccordionContainer>
   )
 
-  return <>{!isMobile ? renderDesktopTabs() : renderMobileAccordion()}</>
+  return (
+    <>
+      {renderDesktopTabs()}
+      {renderMobileAccordion()}
+    </>
+  )
 }
 
 export default ToggleTabs


### PR DESCRIPTION
This PR includes fixes for layouts and useIsMobile. Realizing the challenge of Gatsby is what you see on develop, isn't necessarily what you'll see when it's bundled. Since it's static, the JS doesn't render at the same time. So I'm moving off of `useIsMobile()` hook as a dependency, and instead moving to css media queries.